### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:onbuild
+
+ENTRYPOINT [ "/go/bin/app" ]


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Golang image, onbuild tag. More info at https://hub.docker.com/_/golang/
No Golang install needed on systems with Docker, both for running on production or for developing/testing.

Build:

```
$ docker build -t statsd-vis .
```

Run:

```
$ docker run --rm -it -p 8080:8080 -p 8125:8125/udp -p 8125:8125 statsd-vis -statsdtcp 0.0.0.0:8125 -statsdudp 0.0.0.0:8125  [other statsd-vis options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -p 8080:8080 -p 8125:8125/udp -p 8125:8125 pataquets/statsd-vis-src -statsdtcp 0.0.0.0:8125 -statsdudp 0.0.0.0:8125 [other statsd-vis options...]
```
Using `--rm` causes the container to be deleted after stop. You have to make statsd-vis to listen on 0.0.0.0. Otherwise, it won't be reachable from the outside of the container, since localhost is applied to the container's network stack, not the host.